### PR TITLE
upgraded tapir from 0.11.11 to 1.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 .gradle
 .idea
 .bsp
+.sbt_completion_cache
 
 target/
-

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val tapirVersion = "0.11.11"
+lazy val tapirVersion = "0.19.4"
 lazy val akkaVersion = "2.6.18"
 lazy val akkaHttpVersion = "10.2.8"
 lazy val pac4jVersion = "4.5.4"
@@ -28,8 +28,8 @@ lazy val root =
 lazy val endpoints = (project in file("todo-endpoints")).settings(
   name := "todo-endpoints",
   libraryDependencies := Seq(
-    "com.softwaremill.tapir" %% "tapir-core"       % tapirVersion,
-    "com.softwaremill.tapir" %% "tapir-json-circe" % tapirVersion
+    "com.softwaremill.sttp.tapir" %% "tapir-core"       % tapirVersion,
+    "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion
   )
 )
 
@@ -37,8 +37,8 @@ lazy val apiSpec = (project in file("todo-api-spec"))
   .settings(
     name := "todo-api-spec",
     libraryDependencies := Seq(
-      "com.softwaremill.tapir" %% "tapir-openapi-docs"       % tapirVersion,
-      "com.softwaremill.tapir" %% "tapir-openapi-circe-yaml" % tapirVersion
+      "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % tapirVersion,
+      "com.softwaremill.sttp.tapir" %% "tapir-openapi-circe-yaml" % tapirVersion
     )
   )
   .dependsOn(endpoints)
@@ -46,10 +46,10 @@ lazy val apiSpec = (project in file("todo-api-spec"))
 lazy val server = (project in file("todo-server"))
   .settings(
     libraryDependencies := Seq(
-      "com.typesafe.akka"      %% "akka-actor-typed"       % akkaVersion,
-      "com.typesafe.akka"      %% "akka-stream"            % akkaVersion,
-      "com.typesafe.akka"      %% "akka-http"              % akkaHttpVersion,
-      "com.softwaremill.tapir" %% "tapir-akka-http-server" % tapirVersion,
+      "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
+      "com.typesafe.akka" %% "akka-stream"      % akkaVersion,
+      "com.typesafe.akka" %% "akka-http"        % akkaHttpVersion,
+      "com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % tapirVersion,
       "com.typesafe"                % "config"          % typeSafeConfigVersion,
       "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingVersion,
       "ch.qos.logback"              % "logback-classic" % logbackVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
-lazy val tapirVersion = "0.19.4"
-lazy val akkaVersion = "2.6.18"
-lazy val akkaHttpVersion = "10.2.8"
+lazy val tapirVersion = "1.0.3"
+lazy val openAPICirceYamlVersion = "0.2.1"
+lazy val akkaVersion = "2.6.19"
+lazy val akkaHttpVersion = "10.2.9"
 lazy val pac4jVersion = "4.5.4"
 lazy val pac4jAkkaHttpVersion = "0.7.2"
-lazy val scalaLoggingVersion = "3.9.4"
-lazy val logbackVersion = "1.2.10"
+lazy val scalaLoggingVersion = "3.9.5"
+lazy val logbackVersion = "1.2.11"
 lazy val typeSafeConfigVersion = "1.4.2"
 
 lazy val root =
@@ -28,8 +29,8 @@ lazy val root =
 lazy val endpoints = (project in file("todo-endpoints")).settings(
   name := "todo-endpoints",
   libraryDependencies := Seq(
-    "com.softwaremill.sttp.tapir" %% "tapir-core"       % tapirVersion,
-    "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion
+    "com.softwaremill.sttp.tapir" %% "tapir-core"      % tapirVersion,
+    "com.softwaremill.sttp.tapir" %% "tapir-json-play" % tapirVersion
   )
 )
 
@@ -38,7 +39,7 @@ lazy val apiSpec = (project in file("todo-api-spec"))
     name := "todo-api-spec",
     libraryDependencies := Seq(
       "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % tapirVersion,
-      "com.softwaremill.sttp.tapir" %% "tapir-openapi-circe-yaml" % tapirVersion
+      "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % openAPICirceYamlVersion
     )
   )
   .dependsOn(endpoints)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.7.1

--- a/todo-api-spec/src/main/scala/com/gaston/todo/tapir/api/spec/OpenAPISpec.scala
+++ b/todo-api-spec/src/main/scala/com/gaston/todo/tapir/api/spec/OpenAPISpec.scala
@@ -4,12 +4,16 @@ import com.gaston.todo.tapir.endpoint.Endpoints
 
 object OpenAPISpec extends App {
 
-  import tapir.docs.openapi._
-  import tapir.openapi.OpenAPI
-  import tapir.openapi.circe.yaml._
+  import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
+  import sttp.tapir.openapi.OpenAPI
+  import sttp.tapir.openapi.circe.yaml._
 
   val openAPI: OpenAPI =
-    Endpoints.exposedEndpoints.toOpenAPI("The ToDo API", Endpoints.version)
+    OpenAPIDocsInterpreter().toOpenAPI(
+      Endpoints.exposedEndpoints,
+      "The ToDo API",
+      Endpoints.version
+    )
 
   val yaml = openAPI.toYaml
 

--- a/todo-api-spec/src/main/scala/com/gaston/todo/tapir/api/spec/OpenAPISpec.scala
+++ b/todo-api-spec/src/main/scala/com/gaston/todo/tapir/api/spec/OpenAPISpec.scala
@@ -1,21 +1,20 @@
 package com.gaston.todo.tapir.api.spec
 
 import com.gaston.todo.tapir.endpoint.Endpoints
+import sttp.apispec.openapi.OpenAPI
+import sttp.apispec.openapi.circe.yaml._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 object OpenAPISpec extends App {
 
-  import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
-  import sttp.tapir.openapi.OpenAPI
-  import sttp.tapir.openapi.circe.yaml._
-
-  val openAPI: OpenAPI =
+  lazy val openAPI: OpenAPI =
     OpenAPIDocsInterpreter().toOpenAPI(
       Endpoints.exposedEndpoints,
       "The ToDo API",
       Endpoints.version
     )
 
-  val yaml = openAPI.toYaml
+  lazy val yaml = openAPI.toYaml
 
   println(yaml)
 

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/request/CreateTodoRequest.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/request/CreateTodoRequest.scala
@@ -1,5 +1,7 @@
 package com.gaston.todo.tapir.contract.request
 
+import play.api.libs.json.Json
+
 case class CreateToDoRequest(title: String, description: String)
 
 object CreateToDoRequest {
@@ -7,4 +9,6 @@ object CreateToDoRequest {
     "Read DDD by Eric Evans",
     "Book that shows how to implement DDD in a real project"
   )
+
+  implicit val format = Json.format[CreateToDoRequest]
 }

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/CreateTodoResponse.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/CreateTodoResponse.scala
@@ -1,5 +1,7 @@
 package com.gaston.todo.tapir.contract.response
 
+import play.api.libs.json.Json
+
 import java.util.UUID
 
 case class CreateToDoResponse(id: UUID)
@@ -8,4 +10,6 @@ object CreateToDoResponse {
   val example1 = CreateToDoResponse(
     UUID.fromString("65c6bb19-b576-4019-b569-388ac3f92ce2")
   )
+
+  implicit val format = Json.format[CreateToDoResponse]
 }

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/TodoResponse.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/TodoResponse.scala
@@ -1,5 +1,7 @@
 package com.gaston.todo.tapir.contract.response
 
+import play.api.libs.json.Json
+
 import java.util.UUID
 
 case class ToDoResponse(id: UUID, title: String, description: String)
@@ -16,4 +18,6 @@ object ToDoResponse {
     ""
   )
   val exampleList = List(example1, example2)
+
+  implicit val format = Json.format[ToDoResponse]
 }

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/endpoint/Endpoints.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/endpoint/Endpoints.scala
@@ -1,10 +1,13 @@
 package com.gaston.todo.tapir.endpoint
 
-import com.gaston.todo.tapir.contract.response.ToDoResponse
-import io.circe.generic.auto._
+import com.gaston.todo.tapir.contract.request.CreateToDoRequest
+import com.gaston.todo.tapir.contract.response.{
+  CreateToDoResponse,
+  ToDoResponse
+}
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.json.circe._
+import sttp.tapir.json.play.jsonBody
 
 import java.util.UUID
 
@@ -48,35 +51,33 @@ object Endpoints {
     )
     .errorOut(plainBody[String])
 
-//  val addToDoEndpoint = todoBaseEndpoint.post
-//    .description("creates a new ToDo")
-//    .securityIn(auth.bearer[String])
-//    .securityIn(
-//      jsonBody[CreateToDoRequest]
-//        .description("The ToDo to be saved")
-//        .example(CreateToDoRequest.example1)
-//    )
-//    .out(
-//      jsonBody[CreateToDoResponse]
-//        .description("The ID generated of the saved ToDo")
-//        .example(CreateToDoResponse.example1)
-//    )
+  val addToDoEndpoint = todoBaseEndpoint.post
+    .in(
+      jsonBody[CreateToDoRequest]
+        .description("The ToDo to be saved")
+        .example(CreateToDoRequest.example1)
+    )
+    .description("creates a new ToDo")
+    .out(
+      jsonBody[CreateToDoResponse]
+        .description("The ID generated of the saved ToDo")
+        .example(CreateToDoResponse.example1)
+    )
 
-//  val deleteTodoEndpoint =
-//    todoBaseEndpoint
-//      .securityIn(auth.bearer[String])
-//      .in(path[UUID]("id"))
-//      .delete
-//      .out(plainBody[String])
+  val deleteTodoEndpoint =
+    todoBaseEndpoint
+      .in(path[UUID]("id"))
+      .delete
+      .out(plainBody[String])
 
   val exposedEndpoints =
     List(
       openAPISpec,
       todoDescriptionEndpoint,
       getTodoEndpoint,
-      getToDosEndpoint
-//      addToDoEndpoint,
-//      deleteTodoEndpoint
+      getToDosEndpoint,
+      addToDoEndpoint,
+      deleteTodoEndpoint
     )
 
 }

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/endpoint/Endpoints.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/endpoint/Endpoints.scala
@@ -1,13 +1,10 @@
 package com.gaston.todo.tapir.endpoint
 
-import com.gaston.todo.tapir.contract.request.CreateToDoRequest
-import com.gaston.todo.tapir.contract.response.{
-  CreateToDoResponse,
-  ToDoResponse
-}
+import com.gaston.todo.tapir.contract.response.ToDoResponse
 import io.circe.generic.auto._
-import tapir._
-import tapir.json.circe._
+import sttp.tapir._
+import sttp.tapir.generic.auto._
+import sttp.tapir.json.circe._
 
 import java.util.UUID
 
@@ -51,35 +48,35 @@ object Endpoints {
     )
     .errorOut(plainBody[String])
 
-  val addToDoEndpoint = todoBaseEndpoint.post
-    .description("creates a new ToDo")
-    .in(auth.bearer)
-    .in(
-      jsonBody[CreateToDoRequest]
-        .description("The ToDo to be saved")
-        .example(CreateToDoRequest.example1)
-    )
-    .out(
-      jsonBody[CreateToDoResponse]
-        .description("The ID generated of the saved ToDo")
-        .example(CreateToDoResponse.example1)
-    )
+//  val addToDoEndpoint = todoBaseEndpoint.post
+//    .description("creates a new ToDo")
+//    .securityIn(auth.bearer[String])
+//    .securityIn(
+//      jsonBody[CreateToDoRequest]
+//        .description("The ToDo to be saved")
+//        .example(CreateToDoRequest.example1)
+//    )
+//    .out(
+//      jsonBody[CreateToDoResponse]
+//        .description("The ID generated of the saved ToDo")
+//        .example(CreateToDoResponse.example1)
+//    )
 
-  val deleteTodoEndpoint =
-    todoBaseEndpoint
-      .in(auth.bearer)
-      .in(path[UUID]("id"))
-      .delete
-      .out(plainBody[String])
+//  val deleteTodoEndpoint =
+//    todoBaseEndpoint
+//      .securityIn(auth.bearer[String])
+//      .in(path[UUID]("id"))
+//      .delete
+//      .out(plainBody[String])
 
   val exposedEndpoints =
     List(
       openAPISpec,
       todoDescriptionEndpoint,
       getTodoEndpoint,
-      getToDosEndpoint,
-      addToDoEndpoint,
-      deleteTodoEndpoint
+      getToDosEndpoint
+//      addToDoEndpoint,
+//      deleteTodoEndpoint
     )
 
 }

--- a/todo-server/src/main/scala/com/gaston/todo/tapir/server/Server.scala
+++ b/todo-server/src/main/scala/com/gaston/todo/tapir/server/Server.scala
@@ -4,7 +4,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import com.gaston.todo.tapir.server.repository.ToDosRepository
 import com.gaston.todo.tapir.server.route.Routes
-import com.gaston.todo.tapir.server.security.ServerSecurity
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
 
@@ -15,11 +14,10 @@ object Server extends App {
 
   val config: Config = ConfigFactory.load()
 
-  val akkaHttpSecurity = ServerSecurity.akkaHttpSecurity
   val toDosRepository = new ToDosRepository
   val logger = Logger(this.getClass.getName)
   val port = config.getInt("http.port")
-  val routes = new Routes(toDosRepository, akkaHttpSecurity)
+  val routes = new Routes(toDosRepository)
   implicit val actorSystem: ActorSystem = ActorSystem()
 
   logger.info(s"starting server at $port")

--- a/todo-server/src/main/scala/com/gaston/todo/tapir/server/route/Routes.scala
+++ b/todo-server/src/main/scala/com/gaston/todo/tapir/server/route/Routes.scala
@@ -1,19 +1,18 @@
 package com.gaston.todo.tapir.server.route
 
 import com.gaston.todo.tapir.api.spec.OpenAPISpec
-import com.gaston.todo.tapir.contract.response.ToDoResponse
+import com.gaston.todo.tapir.contract.response.{
+  CreateToDoResponse,
+  ToDoResponse
+}
 import com.gaston.todo.tapir.endpoint.Endpoints
-import com.gaston.todo.tapir.server.repository.ToDosRepository
-import com.stackstate.pac4j.AkkaHttpSecurity
+import com.gaston.todo.tapir.server.repository.{ToDoVO, ToDosRepository}
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class Routes(
-  toDosRepository: ToDosRepository,
-  akkaHttpSecurity: AkkaHttpSecurity
-) {
+class Routes(toDosRepository: ToDosRepository) {
 
   private val openAPISpec = Endpoints.openAPISpec.serverLogic[Future](_ =>
     Future.successful(Right(OpenAPISpec.yaml))
@@ -21,11 +20,10 @@ class Routes(
 
   private val todoDescriptionEndpoint =
     Endpoints.todoDescriptionEndpoint.serverLogic[Future](_ =>
-      Future.successful(Right("waka waka waka"))
-//      Future.successful(Right(s"""
-//                                 | A simple API to create a list of pending ToDos.
-//                                 | The spec can be found in `/api/${Endpoints.version}/spec`
-//                                 |""".stripMargin))
+      Future.successful(Right(s"""
+                                 | A simple API to create a list of pending ToDos.
+                                 | The spec can be found in `/api/${Endpoints.version}/spec`
+                                 |""".stripMargin))
     )
 
   private val getToDosEndpoint =
@@ -50,30 +48,26 @@ class Routes(
     }
 
   private val getTodoEndpoint =
-    Endpoints.getTodoEndpoint.serverLogic { id =>
+    Endpoints.getTodoEndpoint.serverLogic[Future] { id =>
       toDosRepository.getToDo(id) match {
         case Some(todo) => Future(Right(todo))
         case None => Future(Left(s"ToDo $id was not found"))
       }
     }
 
-//  val addToDoEndpoint =
-//    akkaHttpSecurity.withAuthentication("DirectBearerAuthClient") { _ =>
-//      Endpoints.addToDoEndpoint.serverLogic { case (_, toDo) =>
-//        val id =
-//          toDosRepository.addToDo(ToDoVO(toDo.title, toDo.description))
-//        Future(Right(CreateToDoResponse(id)))
-//      }
-//    }
+  val addToDoEndpoint =
+    Endpoints.addToDoEndpoint.serverLogic[Future] { toDo =>
+      val id =
+        toDosRepository.addToDo(ToDoVO(toDo.title, toDo.description))
+      Future(Right(CreateToDoResponse(id)))
+    }
 
-//  val deleteToDoEndpoint =
-//    akkaHttpSecurity.withAuthentication("DirectBearerAuthClient") { _ =>
-//      Endpoints.deleteTodoEndpoint.toRoute { case (_, id) =>
-//        val wasDeleted = toDosRepository.deleteToDo(id)
-//        if (wasDeleted) Future(Right(s"ToDo $id was deleted"))
-//        else Future(Right(s"ToDo $id was not deleted"))
-//      }
-//    }
+  val deleteToDoEndpoint =
+    Endpoints.deleteTodoEndpoint.serverLogic[Future] { id =>
+      val wasDeleted = toDosRepository.deleteToDo(id)
+      if (wasDeleted) Future(Right(s"ToDo $id was deleted"))
+      else Future(Right(s"ToDo $id was not deleted"))
+    }
 
   val routes =
     AkkaHttpServerInterpreter().toRoute(
@@ -84,6 +78,5 @@ class Routes(
         getTodoEndpoint
       )
     )
-//    openAPISpec ~ todoDescriptionEndpoint ~ getTodoEndpoint ~ getToDosEndpoint ~ addToDoEndpoint ~ deleteToDoEndpoint
 
 }

--- a/todo-server/src/main/scala/com/gaston/todo/tapir/server/route/Routes.scala
+++ b/todo-server/src/main/scala/com/gaston/todo/tapir/server/route/Routes.scala
@@ -1,15 +1,11 @@
 package com.gaston.todo.tapir.server.route
 
-import akka.http.scaladsl.server.Directives._
 import com.gaston.todo.tapir.api.spec.OpenAPISpec
-import com.gaston.todo.tapir.contract.response.{
-  CreateToDoResponse,
-  ToDoResponse
-}
+import com.gaston.todo.tapir.contract.response.ToDoResponse
 import com.gaston.todo.tapir.endpoint.Endpoints
-import com.gaston.todo.tapir.server.repository.{ToDoVO, ToDosRepository}
+import com.gaston.todo.tapir.server.repository.ToDosRepository
 import com.stackstate.pac4j.AkkaHttpSecurity
-import tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -19,64 +15,75 @@ class Routes(
   akkaHttpSecurity: AkkaHttpSecurity
 ) {
 
-  private val openAPISpec = Endpoints.openAPISpec.toRoute { _ =>
+  private val openAPISpec = Endpoints.openAPISpec.serverLogic[Future](_ =>
     Future.successful(Right(OpenAPISpec.yaml))
-  }
+  )
 
   private val todoDescriptionEndpoint =
-    Endpoints.todoDescriptionEndpoint.toRoute { _ =>
-      Future.successful(Right(s"""
-                                 | A simple API to create a list of pending ToDos.
-                                 | The spec can be found in `/api/${Endpoints.version}/spec`
-                                 |""".stripMargin))
-    }
+    Endpoints.todoDescriptionEndpoint.serverLogic[Future](_ =>
+      Future.successful(Right("waka waka waka"))
+//      Future.successful(Right(s"""
+//                                 | A simple API to create a list of pending ToDos.
+//                                 | The spec can be found in `/api/${Endpoints.version}/spec`
+//                                 |""".stripMargin))
+    )
 
-  private val getToDosEndpoint = Endpoints.getToDosEndpoint.toRoute {
-    case Some(limit) =>
-      Future.successful(
-        Right(
-          (if (limit < 1) toDosRepository.takeToDos(1)
-           else toDosRepository.takeToDos(limit)).map(row =>
-            ToDoResponse(row.id, row.title, row.description)
+  private val getToDosEndpoint =
+    Endpoints.getToDosEndpoint.serverLogic[Future] {
+      case Some(limit) =>
+        Future.successful(
+          Right(
+            (if (limit < 1) toDosRepository.takeToDos(1)
+             else toDosRepository.takeToDos(limit)).map(row =>
+              ToDoResponse(row.id, row.title, row.description)
+            )
           )
         )
-      )
-    case None =>
-      Future.successful(
-        Right(
-          toDosRepository
-            .takeToDos(5)
-            .map(row => ToDoResponse(row.id, row.title, row.description))
+      case None =>
+        Future.successful(
+          Right(
+            toDosRepository
+              .takeToDos(5)
+              .map(row => ToDoResponse(row.id, row.title, row.description))
+          )
         )
-      )
-  }
-
-  val getTodoEndpoint = Endpoints.getTodoEndpoint.toRoute { id =>
-    toDosRepository.getToDo(id) match {
-      case Some(todo) => Future(Right(todo))
-      case None => Future(Left(s"ToDo $id was not found"))
     }
-  }
 
-  val addToDoEndpoint =
-    akkaHttpSecurity.withAuthentication("DirectBearerAuthClient") { _ =>
-      Endpoints.addToDoEndpoint.toRoute { case (_, toDo) =>
-        val id =
-          toDosRepository.addToDo(ToDoVO(toDo.title, toDo.description))
-        Future(Right(CreateToDoResponse(id)))
+  private val getTodoEndpoint =
+    Endpoints.getTodoEndpoint.serverLogic { id =>
+      toDosRepository.getToDo(id) match {
+        case Some(todo) => Future(Right(todo))
+        case None => Future(Left(s"ToDo $id was not found"))
       }
     }
 
-  val deleteToDoEndpoint =
-    akkaHttpSecurity.withAuthentication("DirectBearerAuthClient") { _ =>
-      Endpoints.deleteTodoEndpoint.toRoute { case (_, id) =>
-        val wasDeleted = toDosRepository.deleteToDo(id)
-        if (wasDeleted) Future(Right(s"ToDo $id was deleted"))
-        else Future(Right(s"ToDo $id was not deleted"))
-      }
-    }
+//  val addToDoEndpoint =
+//    akkaHttpSecurity.withAuthentication("DirectBearerAuthClient") { _ =>
+//      Endpoints.addToDoEndpoint.serverLogic { case (_, toDo) =>
+//        val id =
+//          toDosRepository.addToDo(ToDoVO(toDo.title, toDo.description))
+//        Future(Right(CreateToDoResponse(id)))
+//      }
+//    }
+
+//  val deleteToDoEndpoint =
+//    akkaHttpSecurity.withAuthentication("DirectBearerAuthClient") { _ =>
+//      Endpoints.deleteTodoEndpoint.toRoute { case (_, id) =>
+//        val wasDeleted = toDosRepository.deleteToDo(id)
+//        if (wasDeleted) Future(Right(s"ToDo $id was deleted"))
+//        else Future(Right(s"ToDo $id was not deleted"))
+//      }
+//    }
 
   val routes =
-    openAPISpec ~ todoDescriptionEndpoint ~ getTodoEndpoint ~ getToDosEndpoint ~ addToDoEndpoint ~ deleteToDoEndpoint
+    AkkaHttpServerInterpreter().toRoute(
+      List(
+        openAPISpec,
+        todoDescriptionEndpoint,
+        getToDosEndpoint,
+        getTodoEndpoint
+      )
+    )
+//    openAPISpec ~ todoDescriptionEndpoint ~ getTodoEndpoint ~ getToDosEndpoint ~ addToDoEndpoint ~ deleteToDoEndpoint
 
 }


### PR DESCRIPTION
libs upgraded
- tapir upgraded to 1.0.3
- akka upgraded to 2.6.19
- akk-http upgraded to 10.2.9
- scala-logging upgraded to 3.9.5
- logback-classic upgraded to 1.2.11
- sbt upgraded to 1.7.1

fixes
- Open API Spec is being rendered instead of returning a 500

changes
- replaced circe for play-json
- removed security layer