### PR TITLE
39 - replace play json for jsoniter scala

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 .gradle
 .idea
 .bsp
+.bloop
+.metals
+.vscode
+metals.sbt
 .sbt_completion_cache
 
 target/

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val tapirVersion = "1.0.6"
 lazy val openAPICirceYamlVersion = "0.2.1"
 lazy val akkaVersion = "2.6.19"
 lazy val akkaHttpVersion = "10.2.9"
-lazy val akkaHttpPlayJsonVersion = "1.39.2"
+lazy val akkaHttpJsonVersion = "1.39.2"
 lazy val pac4jVersion = "4.5.4"
 lazy val pac4jAkkaHttpVersion = "0.7.2"
 lazy val scalaLoggingVersion = "3.9.5"
@@ -54,8 +54,10 @@ lazy val root =
 lazy val endpoints = (project in file("todo-endpoints")).settings(
   name := "todo-endpoints",
   libraryDependencies := Seq(
-    "com.softwaremill.sttp.tapir" %% "tapir-core"      % tapirVersion,
-    "com.softwaremill.sttp.tapir" %% "tapir-json-play" % tapirVersion
+    "com.softwaremill.sttp.tapir" %% "tapir-core"           % tapirVersion,
+    "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % tapirVersion,
+    "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.23.0",
+    "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.23.0"
   )
 )
 
@@ -90,7 +92,7 @@ lazy val server = (project in file("todo-server"))
       "org.scalatest"     %% "scalatest"           % scalaTestVersion % Test,
       "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion      % Test,
       "com.typesafe.akka" %% "akka-http-testkit"   % akkaHttpVersion  % Test,
-      "de.heikoseeberger" %% "akka-http-play-json" % akkaHttpPlayJsonVersion % Test,
+      "de.heikoseeberger" %% "akka-http-jsoniter-scala" % akkaHttpJsonVersion % Test,
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % Test,
       "com.dimafeng" %% "testcontainers-scala-postgresql" % testcontainersScalaVersion % Test
     ),

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/request/CreateTodoRequest.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/request/CreateTodoRequest.scala
@@ -1,6 +1,7 @@
 package com.gaston.todo.tapir.contract.request
 
-import play.api.libs.json.Json
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 case class CreateToDoRequest(title: String, description: String)
 
@@ -10,5 +11,7 @@ object CreateToDoRequest {
     "Book that shows how to implement DDD in a real project"
   )
 
-  implicit val format = Json.format[CreateToDoRequest]
+  implicit val codec: JsonValueCodec[CreateToDoRequest] =
+    JsonCodecMaker.make[CreateToDoRequest]
+
 }

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/CreateTodoResponse.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/CreateTodoResponse.scala
@@ -1,6 +1,7 @@
 package com.gaston.todo.tapir.contract.response
 
-import play.api.libs.json.Json
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 import java.util.UUID
 
@@ -11,5 +12,6 @@ object CreateToDoResponse {
     UUID.fromString("65c6bb19-b576-4019-b569-388ac3f92ce2")
   )
 
-  implicit val format = Json.format[CreateToDoResponse]
+  implicit val codec: JsonValueCodec[CreateToDoResponse] =
+    JsonCodecMaker.make[CreateToDoResponse]
 }

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/ErrorResponse.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/ErrorResponse.scala
@@ -1,17 +1,16 @@
 package com.gaston.todo.tapir.contract.response
 
-import play.api.libs.json.Json
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 import java.util.UUID
 
 case class ErrorMessage(id: String, description: String, path: String)
-object ErrorMessage {
-  implicit val format = Json.format[ErrorMessage]
-}
 
 case class ErrorInfo(id: String, status: Int, errors: List[ErrorMessage])
 object ErrorInfo {
-  implicit val format = Json.format[ErrorInfo]
+
+  implicit val codec: JsonValueCodec[ErrorInfo] = JsonCodecMaker.make[ErrorInfo]
 
   val AccessDenied = ErrorInfo(
     "access.denied",

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/TodoResponse.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/contract/response/TodoResponse.scala
@@ -1,6 +1,7 @@
 package com.gaston.todo.tapir.contract.response
 
-import play.api.libs.json.Json
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 import java.util.UUID
 
@@ -19,5 +20,9 @@ object ToDoResponse {
   )
   val exampleList = List(example1, example2)
 
-  implicit val format = Json.format[ToDoResponse]
+  implicit val codec: JsonValueCodec[ToDoResponse] =
+    JsonCodecMaker.make[ToDoResponse]
+
+  implicit val listCodec: JsonValueCodec[List[ToDoResponse]] =
+    JsonCodecMaker.make[List[ToDoResponse]]
 }

--- a/todo-endpoints/src/main/scala/com/gaston/todo/tapir/endpoint/Endpoints.scala
+++ b/todo-endpoints/src/main/scala/com/gaston/todo/tapir/endpoint/Endpoints.scala
@@ -10,7 +10,8 @@ import com.gaston.todo.tapir.contract.response.{
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.generic.auto._
-import sttp.tapir.json.play.jsonBody
+//import sttp.tapir.json.play.jsonBody
+import sttp.tapir.json.jsoniter.jsonBody
 
 import java.util.UUID
 

--- a/todo-server/src/test/scala/com/gaston/todo/tapir/server/api/ToDosApiTest.scala
+++ b/todo-server/src/test/scala/com/gaston/todo/tapir/server/api/ToDosApiTest.scala
@@ -16,7 +16,7 @@ import com.gaston.todo.tapir.server.repository.{
   ToDosRepositoryInMemory
 }
 import com.softwaremill.macwire.wire
-import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
+import de.heikoseeberger.akkahttpjsoniterscala.JsoniterScalaSupport
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig._
@@ -28,7 +28,7 @@ class ToDosApiTest
     extends AnyFunSuite
     with Matchers
     with ScalatestRouteTest
-    with PlayJsonSupport {
+    with JsoniterScalaSupport {
 
   class BaseFixture {
     val appConfig = ConfigSource.default.load[AppConfig] match {


### PR DESCRIPTION
- removed [play-json](https://github.com/playframework/play-json) library as dependency
- added [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala) library as dependency
- integrated `jsoniter-scala` using [JsoniterScalaSupport](https://github.com/hseeberger/akka-http-json/blob/master/akka-http-jsoniter-scala/src/main/scala/de/heikoseeberger/akkahttpjsoniterscala/JsoniterScalaSupport.scala)